### PR TITLE
Fix toast numbering bug

### DIFF
--- a/BlazorAppToast/Pages/ToastContainer.razor
+++ b/BlazorAppToast/Pages/ToastContainer.razor
@@ -17,13 +17,3 @@
         ToastListe.OnToastsUpdated += () => InvokeAsync(StateHasChanged);
    }
 }
-
-
-
-
-
-
-
-
-
-}

--- a/BlazorAppToast/Pages/USeToast.razor
+++ b/BlazorAppToast/Pages/USeToast.razor
@@ -16,7 +16,7 @@
     public void Show()
     {
         Anzahl++;
-        Par1 = "sample " + ToastListe.Toasts.Count()+1.ToString();
+        Par1 = "sample " + (ToastListe.Toasts.Count() + 1).ToString();
         ToastListe.Add(Par1);
     }
 }


### PR DESCRIPTION
## Summary
- fix numbering logic when creating toasts
- remove stray closing brace and blank lines from ToastContainer

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e15002f4832d9d6f52994a2107ca