### PR TITLE
Fix disappearing toast timer issue

### DIFF
--- a/BlazorAppToast/Pages/ToastPopUp.razor
+++ b/BlazorAppToast/Pages/ToastPopUp.razor
@@ -25,6 +25,7 @@
     public Model.ToastListe ToastListe { get; set; }
     [Parameter]
     public string HeadText { get; set; }
+    private Timer _toastTimer;
     public void Remove()
     {
         ToastListe.Remove(HeadText);
@@ -32,9 +33,14 @@
     protected override void OnInitialized()
     {
 
-        var toastTimer = new Timer(10000);
-        toastTimer.Elapsed += (sender, args) => { ToastListe.Remove(HeadText);  };
-        toastTimer.AutoReset = false;
-        toastTimer.Start();
+         _toastTimer = new Timer(10000);
+        _toastTimer.Elapsed += (sender, args) => { ToastListe.Remove(HeadText);  };
+        _toastTimer.AutoReset = false;
+        _toastTimer.Start();
+    }
+
+    public void Dispose()
+    {
+        _toastTimer?.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
- keep a reference to the `Timer` in `ToastPopUp.razor`
- dispose of the timer when the component is removed

The missing reference allowed the timer to be garbage collected before firing, so some notifications never disappeared.

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f8ca24f4832d9a48f996e23c9387