### PR TITLE
Fix toast lifecycle with @key

### DIFF
--- a/BlazorAppToast/Pages/ToastContainer.razor
+++ b/BlazorAppToast/Pages/ToastContainer.razor
@@ -1,10 +1,10 @@
-﻿@using Model 
+﻿@using BlazorAppToast.Model
 <div id="toastcontainer" style="position: absolute; top: 0; right: 0;">
 
-     @foreach (var toast in ToastListe.Toasts)
-      {
-         <ToastPopUp HeadText="@toast.Titel"></ToastPopUp>
-     }
+    @foreach (var toast in ToastListe.Toasts)
+    {
+        <ToastPopUp HeadText="@toast.Titel" @key="@toast.Titel"></ToastPopUp>
+    }
  </div>
  @code {
       [Inject]

--- a/BlazorAppToast/Pages/ToastPopUp.razor
+++ b/BlazorAppToast/Pages/ToastPopUp.razor
@@ -1,4 +1,5 @@
-﻿@using System.Timers 
+﻿@using System.Timers
+@using BlazorAppToast.Model
 
 
 <div class="toast fade show" role="alert" aria-live="assertive" aria-atomic="true">
@@ -22,9 +23,10 @@
 
 @code {
     [Inject]
-    public Model.ToastListe ToastListe { get; set; }
+    public ToastListe ToastListe { get; set; }
     [Parameter]
     public string HeadText { get; set; }
+    private Timer _toastTimer;
     public void Remove()
     {
         ToastListe.Remove(HeadText);
@@ -32,9 +34,14 @@
     protected override void OnInitialized()
     {
 
-        var toastTimer = new Timer(10000);
-        toastTimer.Elapsed += (sender, args) => { ToastListe.Remove(HeadText);  };
-        toastTimer.AutoReset = false;
-        toastTimer.Start();
+         _toastTimer = new Timer(10000);
+        _toastTimer.Elapsed += (sender, args) => { ToastListe.Remove(HeadText);  };
+        _toastTimer.AutoReset = false;
+        _toastTimer.Start();
+    }
+
+    public void Dispose()
+    {
+        _toastTimer?.Dispose();
     }
 }

--- a/BlazorAppToast/Pages/USeToast.razor
+++ b/BlazorAppToast/Pages/USeToast.razor
@@ -1,5 +1,5 @@
 ﻿@page "/usetoast"
-@using Model
+@using BlazorAppToast.Model
 
 <h3>ToastTest</h3>
 <div>


### PR DESCRIPTION
## Summary
- update ToastContainer to supply `@key` when rendering each toast popup
- reference the correct Model namespace across toast components

## Testing
- `dotnet build BlazorAppToast.sln -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f8ca24f4832d9a48f996e23c9387